### PR TITLE
fix deprecated g_type_init call

### DIFF
--- a/src/ldmtool.c
+++ b/src/ldmtool.c
@@ -779,7 +779,9 @@ main(int argc, char *argv[])
     }
     g_option_context_free(context);
 
+    #if !GLIB_CHECK_VERSION(2,35,0)
     g_type_init();
+    #endif
 
     LDM * const ldm = ldm_new(&err);
 


### PR DESCRIPTION
add conditional to g_type_init call to fix FTBFS on systems where
g_type_init is deprecated
