### PR TITLE
Patches to compile in Ubuntu and Debian

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,14 +85,14 @@ PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0 >= 2.32.0],
     ]
 )
 
-PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2.5],
+PKG_CHECK_MODULES([ZLIB], [zlib >= 1.2],
     [
         AC_SUBST([ZLIB_CFLAGS])
         AC_SUBST([ZLIB_LIBS])
     ]
 )
 
-PKG_CHECK_MODULES([UUID], [uuid >= 2.21.0],
+PKG_CHECK_MODULES([UUID], [uuid],
     [
         AC_SUBST([UUID_CFLAGS])
         AC_SUBST([UUID_LIBS])

--- a/src/ldm.c
+++ b/src/ldm.c
@@ -2762,7 +2762,7 @@ _dm_create_mirrored(const LDMVolumePrivate * const vol, GError ** const err)
         GString * chunk = _dm_create_part(part, cookie, err);
         if (chunk == NULL) {
             if (err && (*err)->code == LDM_ERROR_MISSING_DISK) {
-                g_warning((*err)->message);
+                g_warning("%s", (*err)->message);
                 g_error_free(*err); *err = NULL;
                 g_string_append(target.params, " - -");
                 continue;
@@ -2807,7 +2807,7 @@ out:
         for (int i = devices->len; i > 0; i--) {
             GString *device = g_array_index(devices, GString *, i - 1);
             if (!_dm_remove(device->str, 0, &cleanup_err)) {
-                g_warning(cleanup_err->message);
+                g_warning("%s", cleanup_err->message);
                 g_error_free(cleanup_err); cleanup_err = NULL;
             }
         }
@@ -2850,7 +2850,7 @@ _dm_create_raid5(const LDMVolumePrivate * const vol, GError ** const err)
         GString * chunk = _dm_create_part(part, cookie, err);
         if (chunk == NULL) {
             if (err && (*err)->code == LDM_ERROR_MISSING_DISK) {
-                g_warning((*err)->message);
+                g_warning("%s", (*err)->message);
                 g_error_free(*err); *err = NULL;
                 g_string_append(target.params, " - -");
                 continue;
@@ -2895,7 +2895,7 @@ out:
         for (int i = devices->len; i > 0; i--) {
             GString *device = g_array_index(devices, GString *, i - 1);
             if (!_dm_remove(device->str, 0, &cleanup_err)) {
-                g_warning(cleanup_err->message);
+                g_warning("%s", cleanup_err->message);
                 g_error_free(cleanup_err); cleanup_err = NULL;
             }
         }


### PR DESCRIPTION
In order to compile libldm in Ubuntu and Debian, two patches are necessary:
1. Relax version requirements for zlib and uuid
2. Modify g_warning calls that conflict with -Werror=format-security
These patches come from the Debian package available at http://packages.debian.org/source/sid/libldm (unfortunately this Debian package itself is not very usable as it contains an older version of libldm that segfaults in some circumstances). I tested these patches by successfully compiling and running ldmtool under Ubuntu 12.10.
