### PR TITLE
LDM Metadata partition is not recognized if it is not first GPT partition

### DIFF
--- a/src/ldm.c
+++ b/src/ldm.c
@@ -1345,7 +1345,7 @@ _read_privhead_gpt(const int fd, const gchar * const path, const guint secsize,
 
     for (uint32_t i = 0; i < gpt.pte_array_len; i++) {
         gpt_pte_t pte;
-        r = gpt_get_pte(h, 0, &pte);
+        r = gpt_get_pte(h, i, &pte);
         if (r < 0) {
             _map_gpt_error(r, path, err);
             gpt_close(h);

--- a/src/ldmtool.c
+++ b/src/ldmtool.c
@@ -87,7 +87,7 @@ typedef struct {
     const _action_t action;
 } _command_t;
 
-static const _command_t const commands[] = {
+static const _command_t commands[] = {
     { "scan", ldm_scan },
     { "show", ldm_show },
     { "create", ldm_create },


### PR DESCRIPTION
ldmtool cannot recognize LDM Metadata partition on GPT disk if it
is not first partiton in GPT partition table entries.  There are
disks where first partion is Windows Snapshot Partition
(partition type is caddebf1-4400-4de8-b103-12117dcf3ccf).

The commit fixes the bug in the code which inspects partition table
entries in order to find LDM Metadata partion:

_read_privhead_gpt function in ldm.c always calls gpt_get_pte
function with 0 (zero) as a second argument which causes the
described bug.