### PR TITLE
Remove deprecated g_type_class_add_private()

### DIFF
--- a/src/ldm.c
+++ b/src/ldm.c
@@ -312,7 +312,7 @@ struct _LDMPrivate
     GArray *disk_groups;
 };
 
-G_DEFINE_TYPE(LDM, ldm, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE(LDM, ldm, G_TYPE_OBJECT)
 
 static void
 ldm_dispose(GObject * const object)
@@ -345,7 +345,6 @@ ldm_class_init(LDMClass * const klass)
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     object_class->dispose = ldm_dispose;
 
-    g_type_class_add_private(klass, sizeof(LDMPrivate));
 }
 
 /* LDMDiskGroup */
@@ -371,7 +370,7 @@ struct _LDMDiskGroupPrivate
     GArray *comps;
 };
 
-G_DEFINE_TYPE(LDMDiskGroup, ldm_disk_group, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE(LDMDiskGroup, ldm_disk_group, G_TYPE_OBJECT)
 
 enum {
     PROP_LDM_DISK_GROUP_PROP0,
@@ -441,7 +440,6 @@ ldm_disk_group_class_init(LDMDiskGroupClass * const klass)
     object_class->finalize = ldm_disk_group_finalize;
     object_class->get_property = ldm_disk_group_get_property;
 
-    g_type_class_add_private(klass, sizeof(LDMDiskGroupPrivate));
 
     /**
      * LDMDiskGroup:guid:
@@ -537,7 +535,7 @@ struct _LDMVolumePrivate
     guint32 _n_comps_i;
 };
 
-G_DEFINE_TYPE(LDMVolume, ldm_volume, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE(LDMVolume, ldm_volume, G_TYPE_OBJECT)
 
 enum {
     PROP_LDM_VOLUME_PROP0,
@@ -633,7 +631,6 @@ ldm_volume_class_init(LDMVolumeClass * const klass)
     object_class->finalize = ldm_volume_finalize;
     object_class->get_property = ldm_volume_get_property;
 
-    g_type_class_add_private(klass, sizeof(LDMVolumePrivate));
 
     /**
      * LDMVolume:name:
@@ -805,7 +802,7 @@ struct _LDMPartitionPrivate
     LDMDisk *disk;
 };
 
-G_DEFINE_TYPE(LDMPartition, ldm_partition, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE(LDMPartition, ldm_partition, G_TYPE_OBJECT)
 
 enum {
     PROP_LDM_PARTITION_PROP0,
@@ -866,7 +863,6 @@ ldm_partition_class_init(LDMPartitionClass * const klass)
     object_class->finalize = ldm_partition_finalize;
     object_class->get_property = ldm_partition_get_property;
 
-    g_type_class_add_private(klass, sizeof(LDMPartitionPrivate));
 
     /**
      * LDMPartition:name:
@@ -940,7 +936,7 @@ struct _LDMDiskPrivate
     gchar *device; // NULL until device is found
 };
 
-G_DEFINE_TYPE(LDMDisk, ldm_disk, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE(LDMDisk, ldm_disk, G_TYPE_OBJECT)
 
 enum {
     PROP_LDM_DISK_PROP0,
@@ -1018,7 +1014,6 @@ ldm_disk_class_init(LDMDiskClass * const klass)
     object_class->finalize = ldm_disk_finalize;
     object_class->get_property = ldm_disk_get_property;
 
-    g_type_class_add_private(klass, sizeof(LDMDiskPrivate));
 
     /**
      * LDMDisk:name:


### PR DESCRIPTION
The API has been deprecated, which causes build failures,
use the G_DEFINE_TYPE_WITH_PRIVATE() macro instead.

Signed-off-by: Liang Yan <lyan@suse.com>