### PR TITLE
Fix for skipping OEM partitions 

### DIFF
--- a/src/ldm.c
+++ b/src/ldm.c
@@ -1296,7 +1296,7 @@ _read_privhead_off(const int fd, const gchar * const path,
                            sizeof(*privhead) - read,
                            ph_start + read);
         if (in == 0) {
-           g_set_error(err, LDM_ERROR, LDM_ERROR_INVALID,
+            g_set_error(err, LDM_ERROR, LDM_ERROR_INVALID,
                         "%s contains invalid LDM metadata", path);
             return FALSE;
         }


### PR DESCRIPTION
I updated ldm.c to check other partitions for the LDM signature. 
The drive has an OEM/Dell partition which Windows handles but confuses the tool

ldmtool now finds the disk and seems to work

```
disk1 : start=          63, size=      176652, type=de
disk2 : start=      176715, size=   976594357, type=42
disk3 : start=   976771072, size=  2930255872, type=42, bootable
disk4 : start=  3907026944, size=         176, type=42


```
