### PR TITLE
Add ability to override device mapper UUID

### DIFF
--- a/docs/reference/ldmtool/ldmtool.xml
+++ b/docs/reference/ldmtool/ldmtool.xml
@@ -94,6 +94,17 @@
                 </para>
             </listitem>
         </varlistentry>
+        <varlistentry>
+            <term>
+                <option>--uuid_override</option> <replaceable>uuid</replaceable>
+            </term>
+            <listitem>
+                <para>
+                User specified UUID for use with device mapper. This can only be
+                used in single action mode for a single volume.
+                </para>
+            </listitem>
+        </varlistentry>
     </variablelist>
 </refsect1>
 
@@ -151,7 +162,7 @@
 
     <refsect2>
         <title>Single action mode</title>
-        
+
         <para>
         When invoked to run a single action all block devices will be scanned by
         default. In this case, if any block devices are specified with the

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,7 +32,7 @@ bin_PROGRAMS = ldmtool
 ldmtool_CFLAGS = $(AM_CFLAGS) $(GOBJECT_CFLAGS) $(JSON_CFLAGS) \
 		 $(GIO_UNIX_CFLAGS)
 ldmtool_LDADD = -lreadline $(builddir)/$(libname) $(GOBJECT_LIBS) \
-		$(JSON_LIBS) $(GIO_UNIX_LIBS)
+		$(JSON_LIBS) $(GIO_UNIX_LIBS) $(UUID_LIBS)
 
 # GObject introspection fails. This seems to be because g-ir-scanner incorrectly
 # guesses the symbol prefix as 'l_dm', although explicitly passing in the

--- a/src/ldm.h
+++ b/src/ldm.h
@@ -18,6 +18,8 @@
 #ifndef LIBLDM_LDM_H__
 #define LIBLDM_LDM_H__
 
+#include <uuid/uuid.h>
+
 #include <glib-object.h>
 
 G_BEGIN_DECLS
@@ -259,7 +261,7 @@ LDM *ldm_new();
 /**
  * ldm_add:
  * @o: An #LDM object
- * @path: The path of the device 
+ * @path: The path of the device
  * @err: A #GError to receive any generated errors
  *
  * Scan device @path and add its metadata to LDM object @o.
@@ -303,7 +305,7 @@ GArray *ldm_get_disk_groups(LDM *o);
  *
  * Returns: (element-type LDMVolume)(transfer container):
  *      An array of volumes
- */ 
+ */
 GArray *ldm_disk_group_get_volumes(LDMDiskGroup *o);
 
 /**
@@ -496,6 +498,16 @@ gboolean ldm_volume_dm_create(const LDMVolume *o, GString **created,
  */
 gboolean ldm_volume_dm_remove(const LDMVolume *o, GString **removed,
                               GError **err);
+
+/**
+ * ldm_volume_override_uuid:
+ * @o: An #LDMVolume
+ * @uuid_override: User specified UUID for device mapper
+ *
+ * Set the UUID used for device mapper. If no override is set, the volume's
+ * GUID will be used.
+ */
+void ldm_volume_override_uuid(LDMVolume * const o, const uuid_t uuid_override);
 
 /**
  * ldm_partition_get_disk:

--- a/src/ldmtool.c
+++ b/src/ldmtool.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <uuid/uuid.h>
 #include <wordexp.h>
 
 #include <glib-object.h>
@@ -74,13 +75,22 @@ gboolean usage_remove(void)
     return FALSE;
 }
 
-typedef gboolean (*_action_t) (LDM *ldm, gint argc, gchar **argv,
-                               JsonBuilder *jb);
+typedef struct {
+    /* User specified UUID for device mapper */
+    uuid_t uuid_override;
+} _options_t;
 
-gboolean ldm_scan(LDM *ldm, gint argc, gchar **argv, JsonBuilder *jb);
-gboolean ldm_show(LDM *ldm, gint argc, gchar **argv, JsonBuilder *jb);
-gboolean ldm_create(LDM *ldm, gint argc, gchar **argv, JsonBuilder *jb);
-gboolean ldm_remove(LDM *ldm, gint argc, gchar **argv, JsonBuilder *jb);
+typedef gboolean (*_action_t) (LDM *ldm, const _options_t * const opts,
+                               gint argc, gchar **argv, JsonBuilder *jb);
+
+gboolean ldm_scan(LDM *ldm, const _options_t * const opts, gint argc,
+                  gchar **argv, JsonBuilder *jb);
+gboolean ldm_show(LDM *ldm, const _options_t * const opts, gint argc,
+                  gchar **argv, JsonBuilder *jb);
+gboolean ldm_create(LDM *ldm, const _options_t * const opts, gint argc,
+                    gchar **argv, JsonBuilder *jb);
+gboolean ldm_remove(LDM *ldm, const _options_t * const opts, gint argc,
+                    gchar **argv, JsonBuilder *jb);
 
 typedef struct {
     const char * name;
@@ -96,14 +106,15 @@ static const _command_t commands[] = {
 };
 
 gboolean
-do_command(LDM * const ldm, const int argc, char *argv[], gboolean *result,
+do_command(LDM * const ldm, const _options_t * const opts,
+           const int argc, char *argv[], gboolean *result,
            GOutputStream * const out,
            JsonGenerator * const jg, JsonBuilder * const jb)
 {
     const _command_t *i = commands;
     while (i->name) {
         if (g_strcmp0(i->name, argv[0]) == 0) {
-            if ((i->action)(ldm, argc - 1, argv + 1, jb)) {
+            if ((i->action)(ldm, opts, argc - 1, argv + 1, jb)) {
                 GError *err = NULL;
                 json_generator_set_root(jg, json_builder_get_root(jb));
                 if (!json_generator_to_stream(jg, out, NULL, &err)) {
@@ -174,8 +185,8 @@ _scan(LDM *const ldm, gboolean ignore_errors,
 }
 
 gboolean
-ldm_scan(LDM *const ldm, const gint argc, gchar ** const argv,
-         JsonBuilder * const jb)
+ldm_scan(LDM *const ldm, const _options_t * const opts, const gint argc,
+         gchar ** const argv, JsonBuilder * const jb)
 {
     return _scan(ldm, FALSE, argc, argv, jb);
 }
@@ -477,8 +488,8 @@ show_disk(LDM *const ldm, const gint argc, gchar ** const argv,
 }
 
 gboolean
-ldm_show(LDM *const ldm, const gint argc, gchar ** const argv,
-         JsonBuilder * const jb)
+ldm_show(LDM *const ldm, const _options_t * const opts, const gint argc,
+         gchar ** const argv, JsonBuilder * const jb)
 {
     if (argc == 0) return usage_show();
 
@@ -499,8 +510,8 @@ typedef gboolean (*_usage_t)();
 typedef gboolean (*_vol_action_t)(const LDMVolume *, GString **, GError **);
 
 static gboolean
-_ldm_vol_action(LDM *const ldm, const gint argc, gchar ** const argv,
-                JsonBuilder * const jb,
+_ldm_vol_action(LDM *const ldm, const _options_t * const opts, const gint argc,
+                gchar ** const argv, JsonBuilder * const jb,
                 const gchar * const action_desc,
                 _usage_t const usage, _vol_action_t const action)
 {
@@ -508,6 +519,11 @@ _ldm_vol_action(LDM *const ldm, const gint argc, gchar ** const argv,
 
     if (argc == 1) {
         if (g_strcmp0(argv[0], "all") != 0) return (*usage)();
+
+        if (!uuid_is_null(opts->uuid_override)) {
+            g_warning("UUID override cannot be used for multiple volumes");
+            return FALSE;
+        }
 
         GArray *dgs = ldm_get_disk_groups(ldm);
         for (guint i = 0; i < dgs->len; i++) {
@@ -567,6 +583,10 @@ _ldm_vol_action(LDM *const ldm, const gint argc, gchar ** const argv,
             return FALSE;
         }
 
+        if (!uuid_is_null(opts->uuid_override)) {
+            ldm_volume_override_uuid(vol, opts->uuid_override);
+        }
+
         GError *err = NULL;
         GString *device = NULL;
         if (!(*action)(vol, &device, &err)) {
@@ -592,25 +612,30 @@ _ldm_vol_action(LDM *const ldm, const gint argc, gchar ** const argv,
 }
 
 gboolean
-ldm_create(LDM *const ldm, const gint argc, gchar ** const argv,
-           JsonBuilder * const jb)
+ldm_create(LDM *const ldm, const _options_t * const opts, const gint argc,
+           gchar ** const argv, JsonBuilder * const jb)
 {
-    return _ldm_vol_action(ldm, argc, argv, jb,
+    return _ldm_vol_action(ldm, opts, argc, argv, jb,
                            "create", usage_create, ldm_volume_dm_create);
 }
 
 gboolean
-ldm_remove(LDM *const ldm, const gint argc, gchar ** const argv,
-           JsonBuilder * const jb)
+ldm_remove(LDM *const ldm, const _options_t * const opts, const gint argc,
+           gchar ** const argv, JsonBuilder * const jb)
 {
-    return _ldm_vol_action(ldm, argc, argv, jb,
+    return _ldm_vol_action(ldm, opts, argc, argv, jb,
                            "remove", usage_remove, ldm_volume_dm_remove);
 }
 
 gboolean
-shell(LDM * const ldm, gchar ** const devices,
+shell(LDM * const ldm, const _options_t * const opts, gchar ** const devices,
       JsonGenerator * const jg, GOutputStream * const out)
 {
+    if (!uuid_is_null(opts->uuid_override)) {
+        g_warning("UUID override cannot be used in shell mode");
+        return FALSE;
+    }
+
     int history_len = 0;
 
     rl_readline_name = "ldmtool";
@@ -659,7 +684,7 @@ shell(LDM * const ldm, gchar ** const devices,
         free(line);
 
         gboolean result = FALSE;
-        if (!do_command(ldm, argc, argv, &result, out, jg, jb)) {
+        if (!do_command(ldm, opts, argc, argv, &result, out, jg, jb)) {
             if (g_strcmp0("quit", argv[0]) == 0 ||
                 g_strcmp0("exit", argv[0]) == 0)
             {
@@ -739,7 +764,7 @@ get_devices(void)
 }
 
 gboolean
-cmdline(LDM * const ldm, gchar **devices,
+cmdline(LDM * const ldm, const _options_t * const opts, gchar **devices,
         JsonGenerator * const jg, GOutputStream * const out,
         const int argc, char *argv[])
 {
@@ -757,7 +782,7 @@ cmdline(LDM * const ldm, gchar **devices,
 
     jb = json_builder_new();
     gboolean result;
-    if (!do_command(ldm, argc, argv, &result, out, jg, jb)) {
+    if (!do_command(ldm, opts, argc, argv, &result, out, jg, jb)) {
         g_warning("Unrecognised command: %s", argv[0]);
         goto error;
     }
@@ -789,11 +814,14 @@ int
 main(int argc, char *argv[])
 {
     static gchar **devices = NULL;
+    static gchar *uuid_override_str = NULL;
 
     static const GOptionEntry entries[] =
     {
         { "device", 'd', 0, G_OPTION_ARG_FILENAME_ARRAY,
           &devices, "Block device to scan for LDM metadata", NULL },
+        { "uuid_override", 0, 0, G_OPTION_ARG_STRING,
+          &uuid_override_str, "UUID override for device mapper", NULL },
         { NULL }
     };
 
@@ -813,6 +841,17 @@ main(int argc, char *argv[])
     }
     g_option_context_free(context);
 
+    _options_t opts;
+    uuid_clear(opts.uuid_override);
+    if (uuid_override_str) {
+        if (uuid_parse(uuid_override_str, opts.uuid_override)) {
+            g_warning("Failed to parse %s as a UUID", uuid_override_str);
+            return 1;
+        }
+        g_free(uuid_override_str);
+        uuid_override_str = NULL;
+    }
+
 #if !GLIB_CHECK_VERSION(2,35,0)
     g_type_init();
 #endif
@@ -828,11 +867,11 @@ main(int argc, char *argv[])
     json_generator_set_indent(jg, 2);
 
     if (argc > 1) {
-        if (!cmdline(ldm, devices, jg, out, argc - 1, argv + 1)) {
+        if (!cmdline(ldm, &opts, devices, jg, out, argc - 1, argv + 1)) {
             ret = 1;
         }
     } else {
-        if (!shell(ldm, devices, jg, out)) {
+        if (!shell(ldm, &opts, devices, jg, out)) {
             ret = 1;
         }
     }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -21,7 +21,7 @@ EXTRA_DIST = checkmount.pl data/ldm-data.tar.xz
 check_PROGRAMS = partread ldmread
 
 partread_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/src
-partread_LDADD = $(top_builddir)/src/libldm-1.0.la
+partread_LDADD = $(top_builddir)/src/libldm-1.0.la $(UUID_LIBS)
 
 ldmread_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/src $(GOBJECT_CFLAGS)
 ldmread_LDADD = $(top_builddir)/src/libldm-1.0.la $(GOBJECT_LIBS)


### PR DESCRIPTION
# Summary

See https://github.com/mdbooth/libldm/issues/24 for the problem statement.

This diff adds a new command line option `--uuid_override <>` which allows the user to specify the UUID suffix used for device mapper operations. This seems to be the most sensible option since we still get the atomic behavior for a given UUID.

# Usage

Suppose we have a VM composed of `ldm_span_1` and `ldm_span_2`. Suppose we have a cloned VM composed of `ldm_span_1.cpy` and `ldm_span_2.cpy`.

```
$ sudo losetup -a | grep ldm
/dev/loop8: [64769]:131514 (/home/ubuntu/ldm_span_2)
/dev/loop9: [64769]:131515 (/home/ubuntu/ldm_span_1.cpy)
/dev/loop7: [64769]:131513 (/home/ubuntu/ldm_span_1)
/dev/loop10: [64769]:131516 (/home/ubuntu/ldm_span_2.cpy)
```

We can see both VMs have the same disk group GUID, although they are backed by different disks:

```
$ sudo ldmtool scan -d /dev/loop7 -d /dev/loop8
[
  "8b8e67c1-2c14-45da-b742-00cb2dfea3c5"
]
$ sudo ldmtool scan -d /dev/loop9 -d /dev/loop10
[
  "8b8e67c1-2c14-45da-b742-00cb2dfea3c5"
]
```

With ldmtool 0.2.4, we are able to create separate devices for each VM by renaming the device:

```
$ sudo ldmtool create volume 8b8e67c1-2c14-45da-b742-00cb2dfea3c5 Volume1 -d /dev/loop7 -d /dev/loop8
[
  "ldm_vol_MyVGName_Volume1"
]
$ sudo ldmtool create volume 8b8e67c1-2c14-45da-b742-00cb2dfea3c5 Volume1 -d /dev/loop9 -d /dev/loop10
[
]
$ sudo dmsetup rename /dev/mapper/ldm_vol_MyVGName_Volume1 ldm_vol_MyVGName_Volume1_foo
$ sudo ldmtool create volume 8b8e67c1-2c14-45da-b742-00cb2dfea3c5 Volume1 -d /dev/loop9 -d /dev/loop10
[
  "ldm_vol_MyVGName_Volume1"
]
$ sudo dmsetup ls | grep ldm
ldm_vol_MyVGName_Volume1	(253:18)
ldm_vol_MyVGName_Volume1_foo	(253:17)
```

With ldmtool 0.2.5, this no longer works since we match by UUID instead of name:

```
$ sudo ldmtool create volume 8b8e67c1-2c14-45da-b742-00cb2dfea3c5 Volume1 -d /dev/loop7 -d /dev/loop8
[
  "ldm_vol_MyVGName_Volume1"
]
$ sudo ldmtool create volume 8b8e67c1-2c14-45da-b742-00cb2dfea3c5 Volume1 -d /dev/loop9 -d /dev/loop10
[
]
$ sudo dmsetup rename /dev/mapper/ldm_vol_MyVGName_Volume1 ldm_vol_MyVGName_Volume1_foo
$ sudo ldmtool create volume 8b8e67c1-2c14-45da-b742-00cb2dfea3c5 Volume1 -d /dev/loop9 -d /dev/loop10
[
]
$ sudo dmsetup ls | grep ldm
ldm_vol_MyVGName_Volume1_foo	(253:17)
```

With this diff, we are able to manually specify a UUID for use with device mapper so we can deduplicate the volumes:

```
$ sudo ldmtool create volume 8b8e67c1-2c14-45da-b742-00cb2dfea3c5 Volume1 -d /dev/loop9 -d /dev/loop10 --uuid_override ff481dc0-e1e4-4919-a9be-f1b89205065b
[
  "ldm_vol_MyVGName_Volume1"
]
$ sudo dmsetup ls | grep ldm
ldm_vol_MyVGName_Volume1	(253:18)
ldm_vol_MyVGName_Volume1_foo	(253:17)
$ sudo dmsetup info ldm_vol_MyVGName_Volume1_foo | grep UUID
UUID: LDM-Volume1-8b8e67c1-2c14-45da-b742-00cb2dfea3c5
$ sudo dmsetup info ldm_vol_MyVGName_Volume1 | grep UUID
UUID: LDM-Volume1-ff481dc0-e1e4-4919-a9be-f1b89205065b
```

`--uuid_override` is not allowed for shell mode or multiple volumes:

```
$ sudo ldmtool create all -d /dev/loop9 -d /dev/loop10 --uuid_override ff481dc0-e1e4-4919-a9be-f1b89205065b
UUID override cannot be used for multiple volumes
$ sudo ldmtool -d /dev/loop9 -d /dev/loop10 --uuid_override ff481dc0-e1e4-4919-a9be-f1b89205065b
UUID override cannot be used in shell mode
```

# Implementation overview

- In `ldmtool.c`, we introduce an `_options_t` struct to hold the uuid override. This is done for readability and extendability purposes.
- In the `main` function, we parse the UUID and pass the `_options_t` struct down to the subcommand implementation `_ldm_vol_action`.
- In `_ldm_vol_action`, we set the UUID override for a single volume by calling `ldm_volume_override_uuid`.
- After the UUID override is set, `_dm_vol_uuid` will return the override UUID instead of the volume GUID.

# `make check`

```
PASS: 2003R2_SIMPLE
PASS: 2003R2_SPANNED
PASS: 2003R2_STRIPED
PASS: 2003R2_MIRRORED
PASS: 2003R2_RAID5
PASS: 2008R2_SPANNED
PASS: 2008R2_STRIPED
PASS: 2008R2_MIRRORED
PASS: 2008R2_RAID5
PASS: 2003R2_MIRRORED_partial_1
PASS: 2003R2_MIRRORED_partial_2
PASS: 2008R2_MIRRORED_partial_1
PASS: 2008R2_MIRRORED_partial_2
============================================================================
Testsuite summary for libldm 0.2.5
============================================================================
# TOTAL: 13
# PASS:  13
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```