### PR TITLE
libdevmapper error handling: fixed error message.

### DIFF
--- a/src/ldm.c
+++ b/src/ldm.c
@@ -250,6 +250,8 @@ _dm_log_fn(const int level, const char * const file, const int line,
 {
     if (dm_errno == 0) return;
 
+    if (level > 4/*_LOG_WARN*/) return; /* ignore debug messages - libdevmapper has a ton of them */
+
     _dm_err_last_level = level;
     _dm_err_last_file = file;
     _dm_err_last_line = line;


### PR DESCRIPTION
Fixed the bug when the last libdevmapper debug message being shown instead of the real error. The fix is about ignoring low-priority log messages when setting the _dm_err_last_msg and others.