### PR TITLE
Throw an error and avoid working with disks that are in the middle of LDM transaction.

### DIFF
--- a/src/ldm.h
+++ b/src/ldm.h
@@ -38,6 +38,7 @@ GQuark ldm_error_quark(void);
  * @LDM_ERROR_NOTSUPPORTED: Unsupported LDM metadata
  * @LDM_ERROR_MISSING_DISK: A disk is missing from a disk group
  * @LDM_ERROR_EXTERNAL: An error reported by an external library
+ * @LDM_ERROR_UNSAFE: LDM is in the state when it is unsafe to use it
  */
 typedef enum {
     LDM_ERROR_INTERNAL,
@@ -47,7 +48,8 @@ typedef enum {
     LDM_ERROR_INCONSISTENT,
     LDM_ERROR_NOTSUPPORTED,
     LDM_ERROR_MISSING_DISK,
-    LDM_ERROR_EXTERNAL
+    LDM_ERROR_EXTERNAL,
+    LDM_ERROR_UNSAFE
 } LDMError;
 
 #define LDM_TYPE_ERROR (ldm_error_get_type())

--- a/src/ldmtool.c
+++ b/src/ldmtool.c
@@ -153,9 +153,11 @@ _scan(LDM *const ldm, gboolean ignore_errors,
 
                 GError *err = NULL;
                 if (!ldm_add(ldm, path, &err)) {
-                    if (!ignore_errors &&
-                        (err->domain != LDM_ERROR
-                         || err->code != LDM_ERROR_NOT_LDM)) {
+                    if ((!ignore_errors &&
+                         (err->domain != LDM_ERROR
+                          || err->code != LDM_ERROR_NOT_LDM)) ||
+                        (err->domain == LDM_ERROR &&
+                         err->code == LDM_ERROR_UNSAFE)) {
                         g_warning("Error scanning %s: %s", path, err->message);
                     }
                     g_error_free(err); err = NULL;


### PR DESCRIPTION
Especially important if we have "ldmtool create all" running automatically on startup.